### PR TITLE
Update Safari to 6.1.4 for Lion, Mountain Lion

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -86,7 +86,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2014-05-17T06:57:51Z</date>
+	<date>2014-05-26T15:21:54Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AirPortUtility</key>
@@ -169,24 +169,24 @@
 		<key>SafariLion</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 6.1.3 for Lion</string>
+			<string>Safari 6.1.4 for Lion</string>
 			<key>sha1</key>
-			<string>e41ef12c8502eefe028fc9d5af6c8610c3f085a9</string>
+			<string>6a4f10f753a17ca9097547012682707f6aedfd9c</string>
 			<key>size</key>
-			<integer>54398730</integer>
+			<integer>54412045</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/15/57/031-3445/ufnxrdv2eonlvqoavqx3lvqj4woggy313m/Safari6.1.3Lion.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/17/37/031-02224/8gxq9vhxcra3e5adif9fhvafxoefypqvlx/Safari6.1.4Lion.pkg</string>
 		</dict>
 		<key>SafariML</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 6.1.3 for Mountain Lion</string>
+			<string>Safari 6.1.4 for Mountain Lion</string>
 			<key>sha1</key>
-			<string>c3e4863589d410c6b6ae823b7239d27098c8f085</string>
+			<string>0ee38570ab44621cf9a3bd1df9701898893713e9</string>
 			<key>size</key>
-			<integer>52921840</integer>
+			<integer>52932672</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/45/61/031-3448/crheap80pu74m9d6e9d0s1o5lpq4njk262/Safari6.1.3MountainLion.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/20/28/031-02225/l4fvklwmcf442w0ujno5ege16wcx2ncvzm/Safari6.1.4MountainLion.pkg</string>
 		</dict>
 		<key>Security2014-001Lion</key>
 		<dict>


### PR DESCRIPTION
Just updated the SUS URLs for the Safari 6.1.4 updates, as the 6.1.3 versions are now gone. Not yet fully tested.
