### PR TITLE
Safari, Security, and reordering updates

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -151,7 +151,7 @@
 			<key>name</key>
 			<string>Safari 6.2.4 for Mountain Lion</string>
 			<key>sha1</key>
-			<string>10d58dbc7e18ffd4a7d1af95cc28e3f9a8b11759</string>
+			<string>5930a900513318d5f5e48902c29a5065a7953938</string>
 			<key>size</key>
 			<integer>60435848</integer>
 			<key>url</key>
@@ -162,7 +162,7 @@
 			<key>name</key>
 			<string>Safari 7.1.4 for Mavericks</string>
 			<key>sha1</key>
-			<string>d31f2aa1086899ce545f4ea99e4afe21e1c6e66a</string>
+			<string>552d1cb11aa5c3a733eb426bbc96a2c0d75cc764</string>
 			<key>size</key>
 			<integer>61062012</integer>
 			<key>url</key>
@@ -184,7 +184,7 @@
 			<key>name</key>
 			<string>Security Update 2015-002 Mountain Lion</string>
 			<key>sha1</key>
-			<string>a02367296c1201cb3bd7f35c4d184bb3cb6ad7f8</string>
+			<string>21d254e3b98e0f4e5fef74708f7c2add5e1d6172</string>
 			<key>size</key>
 			<integer>176979353</integer>
 			<key>url</key>
@@ -195,7 +195,7 @@
 			<key>name</key>
 			<string>Security Update 2015-002 Mavericks</string>
 			<key>sha1</key>
-			<string>b28018ec18265e7f5f4300d615cc24f8382687d7</string>
+			<string>390b49c6713eb16cb9a62bdc4c80b878a9c5f960</string>
 			<key>size</key>
 			<integer>61734294</integer>
 			<key>url</key>
@@ -206,7 +206,7 @@
 			<key>name</key>
 			<string>Security Update 2015-002 Yosemite</string>
 			<key>sha1</key>
-			<string>cf9899623dd7c5530162f2684dff40cd73409ba8</string>
+			<string>553d936c45b4daa1b1bbda0bd1a95bf37ca57c94</string>
 			<key>size</key>
 			<integer>4808001</integer>
 			<key>url</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -182,24 +182,35 @@
 		<key>SecurityML</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2015-001 Mountain Lion</string>
+			<string>Security Update 2015-002 Mountain Lion</string>
 			<key>sha1</key>
-			<string>da95f2065ade9ed1886c3ad25bad6c0d1ea12de0</string>
+			<string>a02367296c1201cb3bd7f35c4d184bb3cb6ad7f8</string>
 			<key>size</key>
-			<integer>177139104</integer>
+			<integer>176979353</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/11/44/zzz031-11170/4qqiq6yf9jge53941qi4q1m5cykcnh8o9j/SecUpd2015-001MtLion.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/17/01/zzz031-17115/d7go86u00z9r5ha1swg417fxwj9d9jmw8w/SecUpd2015-002MtLion.pkg</string>
 		</dict>
 		<key>SecurityMav</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2015-001 Mavericks</string>
+			<string>Security Update 2015-002 Mavericks</string>
 			<key>sha1</key>
-			<string>80be5a2ab9be32d9cba7d361d0fce101dc9cf79a</string>
+			<string>b28018ec18265e7f5f4300d615cc24f8382687d7</string>
 			<key>size</key>
-			<integer>61758881</integer>
+			<integer>61734294</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/19/17/zzz031-11172/f2t4z9jv5wngqom86iifqhcp1xrqsnr8e7/SecUpd2015-001Mavericks.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/31/07/zzz031-17121/jxjpyucwn1ais8bsuwfdgrbnv0stjp97a7/SecUpd2015-002Mavericks.pkg</string>
+		</dict>
+		<key>SecurityYo</key>
+		<dict>
+			<key>name</key>
+			<string>Security Update 2015-002 Yosemite</string>
+			<key>sha1</key>
+			<string>cf9899623dd7c5530162f2684dff40cd73409ba8</string>
+			<key>size</key>
+			<integer>4808001</integer>
+			<key>url</key>
+			<string>http://swcdn.apple.com/content/downloads/27/28/zzz031-18424/2mksq9jzfv6snmgs70a6qhmw68ektytdre/SecUpd2015-002Yosemite.pkg</string>
 		</dict>
 		<key>iBooks</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -99,7 +99,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2015-02-11T23:03:35Z</date>
+	<date>2015-03-17T20:09:29Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AirPortUtility</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -173,7 +173,7 @@
 			<key>name</key>
 			<string>Safari 8.0.4 for Yosemite</string>
 			<key>sha1</key>
-			<string>4bac2e33fb6393544e22286d748ab88050401f6e</string>
+			<string>74b6f6d978321ea7fc4e4a644e6cf8ae7bc355a4</string>
 			<key>size</key>
 			<integer>68878547</integer>
 			<key>url</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -67,34 +67,35 @@
 		<key>10.10.2-14C109</key>
 		<array>
 			<string>RemoteDesktopClient</string>
-			<string>iTunes</string>
+			<string>SafariYo</string>
+			<string>SecurityYo</string>
 		</array>
 		<key>10.8.5-12F2015</key>
 		<array>
-			<string>iTunes</string>
-			<string>AppStoreML</string>
-			<string>AirPortUtility</string>
-			<string>SecurityML</string>
 			<string>SafariML</string>
 			<string>RemoteDesktopClient</string>
+			<string>iTunes</string>
+			<string>AirPortUtility</string>
+			<string>SecurityML</string>
+			<string>AppStoreML</string>
 		</array>
 		<key>10.8.5-12F45</key>
 		<array>
-			<string>iTunes</string>
-			<string>AppStoreML</string>
-			<string>AirPortUtility</string>
-			<string>SecurityML</string>
 			<string>SafariML</string>
 			<string>RemoteDesktopClient</string>
+			<string>iTunes</string>
+			<string>AirPortUtility</string>
+			<string>SecurityML</string>
+			<string>AppStoreML</string>
 		</array>
 		<key>10.9.5-13F34</key>
 		<array>
+			<string>RemoteDesktopClient</string>
+			<string>SafariMav</string>
 			<string>iBooks</string>
 			<string>BookKit</string>
-			<string>iTunes</string>
-			<string>SafariMav</string>
 			<string>SecurityMav</string>
-			<string>RemoteDesktopClient</string>
+			<string>iTunes</string>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
@@ -148,24 +149,35 @@
 		<key>SafariML</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 6.2.3 for Mountain Lion</string>
+			<string>Safari 6.2.4 for Mountain Lion</string>
 			<key>sha1</key>
-			<string>703a3fbdf7d424abc863b2297b6e996091829098</string>
+			<string>10d58dbc7e18ffd4a7d1af95cc28e3f9a8b11759</string>
 			<key>size</key>
-			<integer>60426742</integer>
+			<integer>60435848</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/54/37/031-10992/mlnex0jsu7f1nougez6txwp7x99p9nd3br/Safari6.2.3MountainLion.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/43/27/031-17825/iwos0451bpdeq74i1biixjq2r7lxmi7ezi/Safari6.2.4MountainLion.pkg</string>
 		</dict>
 		<key>SafariMav</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 7.1.3 for Mavericks</string>
+			<string>Safari 7.1.4 for Mavericks</string>
 			<key>sha1</key>
-			<string>7f07fed390f6502edf405a84f43e379723f127e5</string>
+			<string>d31f2aa1086899ce545f4ea99e4afe21e1c6e66a</string>
 			<key>size</key>
-			<integer>61054391</integer>
+			<integer>61062012</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/30/44/031-10995/p6d3vvqi0fwg33yjmtsv9h0snd1dtnp0p1/Safari7.1.3Mavericks.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/54/13/031-17828/4gpelv4z8bjiy2pvtxacg3mghv7w30ou99/Safari7.1.4Mavericks.pkg</string>
+		</dict>
+		<key>SafariYo</key>
+		<dict>
+			<key>name</key>
+			<string>Safari 8.0.4 for Yosemite</string>
+			<key>sha1</key>
+			<string>4bac2e33fb6393544e22286d748ab88050401f6e</string>
+			<key>size</key>
+			<integer>68878547</integer>
+			<key>url</key>
+			<string>http://swcdn.apple.com/content/downloads/53/38/031-17831/xm6yjkk13e2axuwutxeq0zsn2s2ppt34d8/Safari8.0.4Yosemite.pkg</string>
 		</dict>
 		<key>SecurityML</key>
 		<dict>


### PR DESCRIPTION
I named the branch Safari before realizing sec002 wasn't in there yet either.

Reordered to match freshly installed 10.8.5, 10.9.5, and 10.10.2 softwareupdate -la output. 

Tested deployment post AutoDMG creation on

10.8.5 = 13 mbp
10.9.5 = 13 mba
10.10.2 = 13 mba

no trouble found. no softwareupdates available after login