### PR TITLE
Updated for MacBookPro11,4 and MacBookPro11,5, build 14D2134.

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -107,7 +107,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2015-05-07T12:34:50Z</date>
+	<date>2015-05-26T19:15:50Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AirPortUtility</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>DeprecatedInstallers</key>
 	<dict>
-		<key>10.10.3-14D2134</key>
+		<key>10.10.3-14D136</key>
 		<array>
 			<string>10.10-14A299l</string>
 			<string>10.10-14A329r</string>
@@ -20,7 +20,6 @@
 			<string>10.10.2-14C2043</string>
 			<string>10.10.2-14C2055</string>
 			<string>10.10.3-14D131</string>
-			<string>10.10.3-14D136</string>
 		</array>
 		<key>10.7.5-11G63</key>
 		<array>
@@ -70,6 +69,11 @@
 	<key>Profiles</key>
 	<dict>
 		<key>10.10.3-14D2134</key>
+		<array>
+			<string>iTunes</string>
+			<string>SafariYo</string>
+		</array>
+		<key>10.10.3-14D136</key>
 		<array>
 			<string>iTunes</string>
 			<string>SafariYo</string>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>DeprecatedInstallers</key>
 	<dict>
-		<key>10.10.3-14D136</key>
+		<key>10.10.3-14D2134</key>
 		<array>
 			<string>10.10-14A299l</string>
 			<string>10.10-14A329r</string>
@@ -20,6 +20,7 @@
 			<string>10.10.2-14C2043</string>
 			<string>10.10.2-14C2055</string>
 			<string>10.10.3-14D131</string>
+			<string>10.10.3-14D136</string>
 		</array>
 		<key>10.7.5-11G63</key>
 		<array>
@@ -68,7 +69,7 @@
 	</dict>
 	<key>Profiles</key>
 	<dict>
-		<key>10.10.3-14D136</key>
+		<key>10.10.3-14D2134</key>
 		<array>
 			<string>iTunes</string>
 			<string>SafariYo</string>


### PR DESCRIPTION
This time without deprecating 14D136 in the process and with correct PublicationDate timestamp.