### PR TITLE
Remove Camera Raw from Yosemite - not applicable, should be 10.11 only

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -86,7 +86,6 @@
 			<string>iTunes</string>
 			<string>SafariYo</string>
 			<string>SecurityYo</string>
-			<string>CameraRaw</string>
 		</array>
 		<key>10.11.3-15D21</key>
 		<array>
@@ -121,7 +120,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2016-01-19T19:39:40Z</date>
+	<date>2016-01-30T03:18:57Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AirPortUtility</key>


### PR DESCRIPTION
I think I added this at the end of Yosemite testing earlier assuming it applied, but it didn't. 10.10.5 doesn't provide any Camera Raw updates and ships with 6.04.1 in /S/L/CoreServices/RawCamera.

Tested a full rebuild with this new profile to verify.