### PR TITLE
Create AutoDMG app support dir if it doesn't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,4 +10,8 @@ fi
 if ! ./autodmg-verify.py "$plist"; then
     exit 1
 fi
+
+if [[ ! -d ~/Library/Application\ Support/AutoDMG ]]; then
+    mkdir ~/Library/Application\ Support/AutoDMG
+fi
 cp -v "$plist" ~/Library/Application\ Support/AutoDMG/


### PR DESCRIPTION
Just a small change for a case I ran into where I'd recently wiped my AutoDMG app support dir and so the `cp` line at the end failed.