### PR TITLE
Original URL deprecated (metadata/dist only?)

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -183,7 +183,7 @@
 			<key>size</key>
 			<integer>63186815</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/47/05/031-75479/smgdhqybff3jofycbq8uuciu5td7co45am/Safari9.1.3Mavericks.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/47/05/031-75479/4l0mviuw0q0eey0tl79gwl4cillof6yyp0/Safari9.1.3Mavericks.pkg</string>
 		</dict>
 		<key>SafariYo</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -127,7 +127,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2016-09-21T14:35:15Z</date>
+	<date>2016-10-15T15:21:22Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>BookKit</key>


### PR DESCRIPTION
It checksums the same, but is at a new URL. Fixes #44