### PR TITLE
Add updates from May 15

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -36,7 +36,7 @@
 			<string>15E65</string>
 			<string>15F34</string>
 		</array>
-		<key>10.12.4-16E195</key>
+		<key>10.12.5-16F73</key>
 		<array>
 			<string>16A323</string>
 			<string>16A322</string>
@@ -50,6 +50,7 @@
 			<string>16C67</string>
 			<string>16C68</string>
 			<string>16D32</string>
+			<string>16E195</string>
 		</array>
 		<key>10.9.5-13F34</key>
 		<array>
@@ -72,7 +73,7 @@
 	</array>
 	<key>Profiles</key>
 	<dict>
-		<key>10.10.5-14F2315</key>
+		<key>10.10.5-14F2411</key>
 		<array>
 		</array>
 		<key>10.10.5-14F27</key>
@@ -82,7 +83,7 @@
 			<string>SecurityYo</string>
 			<string>SafariYo</string>
 		</array>
-		<key>10.11.6-15G1421</key>
+		<key>10.11.6-15G1510</key>
 		<array>
 		</array>
 		<key>10.11.6-15G31</key>
@@ -92,8 +93,9 @@
 			<string>iTunes</string>
 			<string>SecurityElCap</string>
 			<string>SafariElCap</string>
+			<string>AppStoreElCap</string>
 		</array>
-		<key>10.12.4-16E195</key>
+		<key>10.12.5-16F73</key>
 		<array>
 			<string>RemoteDesktopClient</string>
 			<string>iTunes</string>
@@ -109,9 +111,20 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2017-03-30T08:40:56Z</date>
+	<date>2017-05-15T18:19:56Z</date>
 	<key>Updates</key>
 	<dict>
+		<key>AppStoreElCap</key>
+		<dict>
+			<key>name</key>
+			<string>Mac App Store Update for OS X El Capitan</string>
+			<key>sha1</key>
+			<string>9245bc2b4828665b6b126d676cb610b78bfa68ed</string>
+			<key>size</key>
+			<integer>4787605</integer>
+			<key>url</key>
+			<string>http://swcdn.apple.com/content/downloads/61/61/091-10728/i82m5auvwlrwtyd8moumo7sfzr52npkyyh/MacAppStoreUpdateforElCapitan.pkg</string>
+		</dict>
 		<key>BookKit</key>
 		<dict>
 			<key>name</key>
@@ -148,13 +161,13 @@
 		<key>SafariElCap</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 10.1 for El Capitan</string>
+			<string>Safari 10.1.1 for El Capitan</string>
 			<key>sha1</key>
-			<string>194c29b49559bda3571afb89692e09f4359f6b13</string>
+			<string>037005b0df008fe70f5843b09363bd7aa008a4b1</string>
 			<key>size</key>
-			<integer>73162131</integer>
+			<integer>73117080</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/14/31/031-98397/uqyupa16qtlpbx551inlbir40bpt1pq3yu/Safari10.1ElCapitan.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/27/23/091-03063/2354sgxgndmvy5w4rruif7f3aw5uphchvr/Safari10.1.1ElCapitan.pkg</string>
 		</dict>
 		<key>SafariMav</key>
 		<dict>
@@ -170,24 +183,24 @@
 		<key>SafariYo</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 10.1 for Yosemite</string>
+			<string>Safari 10.1.1 for Yosemite</string>
 			<key>sha1</key>
-			<string>ce887a5ab7d4234e733b404aa0e1c38240a44f66</string>
+			<string>fa033537f17990c5609d057a7f88587e706b4f41</string>
 			<key>size</key>
-			<integer>72797578</integer>
+			<integer>72822161</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/50/60/031-94475/5kj2ecm3p7qrlionzdq4k38xcaczrc9gue/Safari10.1Yosemite.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/08/23/091-02722/anzj6rcuourekx784i99cz29rd472rb3yp/Safari10.1.1Yosemite.pkg</string>
 		</dict>
 		<key>SecurityElCap</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2017-001 (El Capitan)</string>
+			<string>Security Update 2017-002 (El Capitan)</string>
 			<key>sha1</key>
-			<string>e269f9adb5fedaa0cf48ffeb1ae85e9b2582cc59</string>
+			<string>502aafd298cac5f524fdab1daf6a7674e27728cd</string>
 			<key>size</key>
-			<integer>700644770</integer>
+			<integer>710622744</integer>
 			<key>url</key>
-			<string>http://support.apple.com/downloads/DL1914/en_US/SecUpd2017-001ElCapitan.dmg</string>
+			<string>http://support.apple.com/downloads/DL1920/en_US/secupd2017-002elcapitan.dmg</string>
 		</dict>
 		<key>SecurityMav</key>
 		<dict>
@@ -203,13 +216,13 @@
 		<key>SecurityYo</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2017-001 (Yosemite)</string>
+			<string>Security Update 2017-002 (Yosemite)</string>
 			<key>sha1</key>
-			<string>b0d9d7dc2b20425f43d821a5ba5387333d9d4912</string>
+			<string>9998bccdd6bd05e06b7da21fbb7835e7fe370de5</string>
 			<key>size</key>
-			<integer>495175082</integer>
+			<integer>421094826</integer>
 			<key>url</key>
-			<string>http://support.apple.com/downloads/DL1915/en_US/SecUpd2017-001Yosemite.dmg</string>
+			<string>http://support.apple.com/downloads/DL1919/en_US/secupd2017-002yosemite.dmg</string>
 		</dict>
 		<key>iBooks</key>
 		<dict>
@@ -225,13 +238,13 @@
 		<key>iTunes</key>
 		<dict>
 			<key>name</key>
-			<string>iTunes 12.6</string>
+			<string>iTunes 12.6.1</string>
 			<key>sha1</key>
-			<string>ae2fe4782587f96243cac3a7ca71c6912bcac6d5</string>
+			<string>84e287316015603e3a1687af6a0577ea2679b0c3</string>
 			<key>size</key>
-			<integer>282325000</integer>
+			<integer>282989992</integer>
 			<key>url</key>
-			<string>https://secure-appldnld.apple.com/itunes12/091-04056-20170323-5E341721-ECFC-427B-803F-D740CD168D07/iTunes12.6.dmg</string>
+			<string>https://secure-appldnld.apple.com/itunes12/091-14260-20170515-42ED3D8C-369B-11E7-BA5D-08A72DBC0DB3/iTunes12.6.1.dmg</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
I've verified Sierra, but not yet El Cap or Yosemite. Only notable difference here should be the App Store Update for El Cap, which I wouldn't expect to show up as a download on https://support.apple.com/downloads.