### PR TITLE
Fix Safari update in Yosemite

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -92,7 +92,6 @@
 		<key>10.10.5-14F27</key>
 		<array>
 			<string>RemoteDesktopClient</string>
-			<string>iTunes</string>
 			<string>SecurityYo</string>
 			<string>SafariYo</string>
 		</array>
@@ -115,7 +114,7 @@
 		</array>
 		<key>10.13.3-17D47</key>
 		<array>
-			<string>iTunes</string>
+			<string>iTunesHighSierra</string>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
@@ -221,7 +220,7 @@
 			<key>url</key>
 			<string>http://support.apple.com/downloads/DL1933/en_US/secupd2017-003yosemite.dmg</string>
 		</dict>
-		<key>iTunes</key>
+		<key>iTunesHighSierra</key>
 		<dict>
 			<key>name</key>
 			<string>iTunes 12.7.3</string>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -119,7 +119,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2018-01-25T06:54:13Z</date>
+	<date>2018-03-01T22:21:11Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AppStoreElCap</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -93,6 +93,7 @@
 		<array>
 			<string>RemoteDesktopClient</string>
 			<string>SecurityYo</string>
+			<string>SafariYo</string>
 		</array>
 		<key>10.11.6-15G31</key>
 		<array>
@@ -174,6 +175,17 @@
 			<integer>76086686</integer>
 			<key>url</key>
 			<string>http://swcdn.apple.com/content/downloads/16/23/091-45578/vcwdecdjn4lxx2yyteucqnt2wim6gnchhe/Safari11.0.3Sierra.pkg</string>
+		</dict>
+		<key>SafariYo</key>
+		<dict>
+			<key>name</key>
+			<string>Safari 10.1.2 for Yosemite</string>
+			<key>sha1</key>
+			<string>86b8af542c1a8d35c5fc64a477733afe828a51c2</string>
+			<key>size</key>
+			<integer>73194892</integer>
+			<key>url</key>
+			<string>http://swcdn.apple.com/content/downloads/49/15/091-22830/wb37hl4mbck89pw6j4t386ym6q8d5p1g5m/Safari10.1.2Yosemite.pkg</string>
 		</dict>
 		<key>SecurityElCap</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -92,6 +92,7 @@
 		<key>10.10.5-14F27</key>
 		<array>
 			<string>RemoteDesktopClient</string>
+			<string>iTunes</string>
 			<string>SecurityYo</string>
 			<string>SafariYo</string>
 		</array>
@@ -114,7 +115,7 @@
 		</array>
 		<key>10.13.3-17D47</key>
 		<array>
-			<string>iTunesHighSierra</string>
+			<string>iTunes</string>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
@@ -220,7 +221,7 @@
 			<key>url</key>
 			<string>http://support.apple.com/downloads/DL1933/en_US/secupd2017-003yosemite.dmg</string>
 		</dict>
-		<key>iTunesHighSierra</key>
+		<key>iTunes</key>
 		<dict>
 			<key>name</key>
 			<string>iTunes 12.7.3</string>


### PR DESCRIPTION
I attempted to do iTunes 12.7.3 as well but it hangs on launch.