### PR TITLE
Updates 10.13.6, SecUpd2018-004, and Safari 11.1.2

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -132,7 +132,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2018-07-11T21:22:33Z</date>
+	<date>2018-07-13T17:06:31Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AppStoreElCap</key>
@@ -171,24 +171,24 @@
 		<key>SafariElCap</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 11.1.1 for El Capitan</string>
+			<string>Safari 11.1.2 for El Capitan</string>
 			<key>sha1</key>
-			<string>7942228fafbd6e4876cd6d780d86ea2dd9e9b1d5</string>
+			<string>c1aca61c30f3ceea373956b28b9e1f5e0b5270f4</string>
 			<key>size</key>
-			<integer>77917598</integer>
+			<integer>79330675</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/62/45/091-77731/9hcvul9sqn3dq0j4h9362w3chkwj2ihqn7/Safari11.1.1ElCapitan.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/60/50/091-84014/kxld7h4nhhnektja3lkfwqlv6ml8r4psxx/Safari11.1.2ElCapitan.pkg</string>
 		</dict>
 		<key>SafariSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 11.1.1 for Sierra</string>
+			<string>Safari 11.1.2 for Sierra</string>
 			<key>sha1</key>
-			<string>ca850b5be92f9527ed71ef6bdd240426ab5ebd12</string>
+			<string>331f5d21bd0eecc1b04f58977b88eb08763c4e49</string>
 			<key>size</key>
-			<integer>79834517</integer>
+			<integer>79834518</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/09/51/091-75784/xxae706zt4nwlnxjguf8eud13h6gkd8c6i/Safari11.1.1Sierra.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/20/17/091-83945/2bu9iw6dmccjoqnoghfww55hlssmmr2hqq/Safari11.1.2Sierra.pkg</string>
 		</dict>
 		<key>SafariYo</key>
 		<dict>
@@ -204,24 +204,24 @@
 		<key>SecurityElCap</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2018-003 (El Capitan)</string>
+			<string>Security Update 2018-004 (El Capitan)</string>
 			<key>sha1</key>
-			<string>e598ee89055b424743b73eff6e2091d57d09a668</string>
+			<string>6302515a975a72ffb5a4b58ea65315af3e06cc6a</string>
 			<key>size</key>
-			<integer>873848226</integer>
+			<integer>900459938</integer>
 			<key>url</key>
-			<string>http://updates-http.cdn-apple.com/2018/macos/091-86641-20180604-B127CE66-C99A-43F2-8456-5CC14A75929B/SecUpd2018-003ElCapitan.dmg</string>
+			<string>http://updates-http.cdn-apple.com/2018/macos/091-63420-94327-20180709-5409BA12-7C10-11E8-84CF-4F47544C24EB/SecUpd2018-004ElCapitan.dmg</string>
 		</dict>
 		<key>SecuritySierra</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2018-003 (Sierra)</string>
+			<string>Security Update 2018-004 (Sierra)</string>
 			<key>sha1</key>
-			<string>c1cfac3c2ff34da58dce746c6218854cfa986df7</string>
+			<string>9332acabc82146aa85eaf5abfabd9680edfed1a5</string>
 			<key>size</key>
-			<integer>778200656</integer>
+			<integer>786586361</integer>
 			<key>url</key>
-			<string>http://updates-http.cdn-apple.com/2018/macos/091-58224-20180601-E393DE12-F342-4258-9851-7B623E6D249B/SecUpd2018-003Sierra.dmg</string>
+			<string>http://updates-http.cdn-apple.com/2018/macos/091-65274-94327-20180709-5409BA12-7C10-11E8-84CF-4F47544C24EB/SecUpd2018-004Sierra.dmg</string>
 		</dict>
 		<key>SecurityYo</key>
 		<dict>


### PR DESCRIPTION
  - Updated `Updates`:
    - `SafariElCap` with Safari 11.1.2 for El Capitan
    - `SafariSierra` with Safari 11.1.2 for Sierra
    - `SecurityElCap` with Security Update 2018-004 (El Capitan)
    - `SecuritySierra` with Security Update 2018-004 (Sierra)