### PR TITLE
10.13.6 17G2208 installer support + SecUpd2018-003High Sierra

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -61,7 +61,7 @@
 			<string>16G1314</string>
 			<string>16G1710</string>
 		</array>
-		<key>10.13.6-17G65</key>
+		<key>10.13.6-17G2208</key>
 		<array>
 			<string>17A306f</string>
 			<string>17A291m</string>
@@ -83,6 +83,7 @@
 			<string>17D47</string>
 			<string>17E199</string>
 			<string>17F77</string>
+			<string>17G65</string>
 		</array>
 		<key>10.14.2-18C54</key>
 		<array>
@@ -138,18 +139,17 @@
 			<string>SecuritySierra</string>
 			<string>SafariSierra</string>
 		</array>
-		<key>10.13.6-17G65</key>
+		<key>10.13.6-17G2208</key>
 		<array>
 			<string>SafariHighSierra</string>
 			<string>SecurityHighSierra</string>
-			<string>iTunesHighSierra</string>
 		</array>
 		<key>10.14.2-18C54</key>
 		<array>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2019-01-05T17:37:27Z</date>
+	<date>2019-01-09T18:55:39Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AppStoreElCap</key>
@@ -243,13 +243,13 @@
 		<key>SecurityHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2018-002 (High Sierra)</string>
+			<string>Security Update 2018-003 (High Sierra)</string>
 			<key>sha1</key>
-			<string>0bea41b47775b0309af2cb94005835c7b485102a</string>
+			<string>62cb0fcd60567213ed13f5c33a580b2c815e99f9</string>
 			<key>size</key>
-			<integer>1815309721</integer>
+			<integer>1819732313</integer>
 			<key>url</key>
-			<string>http://updates-http.cdn-apple.com/2018/macos/041-18192-20181030-10052238-C103-11E8-A480-9257C82E983B/SecUpd2018-002Sierra.dmg</string>
+			<string>http://updates-http.cdn-apple.com/2018/macos/041-20507-20181205-A9886AC4-DD54-11E8-9E09-B93A2F73053F/SecUpd2018-003HighSierra.dmg</string>
 		</dict>
 		<key>SecuritySierra</key>
 		<dict>
@@ -272,17 +272,6 @@
 			<integer>431572394</integer>
 			<key>url</key>
 			<string>http://support.apple.com/downloads/DL1933/en_US/secupd2017-003yosemite.dmg</string>
-		</dict>
-		<key>iTunesHighSierra</key>
-		<dict>
-			<key>name</key>
-			<string>iTunes 12.8</string>
-			<key>sha1</key>
-			<string>c0c82adb920626fc500134732c4de2e0de6ea235</string>
-			<key>size</key>
-			<integer>275915484</integer>
-			<key>url</key>
-			<string>https://secure-appldnld.apple.com/itunes12/091-81690-20180709-3C97E2AB-D6CC-4B92-B290-2F21E56F6F70/iTunes12.8.dmg</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
 * Now supporting `Install macOS High Sierra.app` (`17G2208`) the important content of which is pulled from SWUP (091-95155).

 * Updated `Updates`:
    * `SecurityHighSierra` with Security Update 2018-003 (High Sierra)
    * Removed `iTunesHighSierra`