### PR TITLE
Various 10.12, 10.13, 10.14 updates

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -227,13 +227,13 @@
 		<key>SafariHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 12.1.1 for High Sierra</string>
+			<string>Safari 12.1.2 for High Sierra</string>
 			<key>sha1</key>
-			<string>bb48a5582ba1fbdd7e42ba74d8bd3f4389d0c8c5</string>
+			<string>4bf6af19df987733ef05116be19c247024e7e15f</string>
 			<key>size</key>
-			<integer>81726835</integer>
+			<integer>81726824</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/11/43/041-29455/th6as97r3li57d3lz5qwgsxdj09bat1u4t/Safari12.1.1HighSierraAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/56/57/041-56829/gd0grk5m1bos9qcnc63nqpbbe2x18xbtie/Safari12.1.2HighSierraAuto.pkg</string>
 		</dict>
 		<key>SafariSierra</key>
 		<dict>
@@ -271,13 +271,13 @@
 		<key>SecurityHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2019-003 (High Sierra)</string>
+			<string>Security Update 2019-004 (High Sierra)</string>
 			<key>sha1</key>
-			<string>f400e4a441a4196be69b6cd4e305d07b92f62b29</string>
+			<string>84d7a23dfbc9d4ac2232a6cc36813047ed98cf4f</string>
 			<key>size</key>
-			<integer>1896131149</integer>
+			<integer>1896069285</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2019/macos/041-44077-20190513-d9861062-6711-4f19-8641-49e0d88627ff/SecUpd2019-003HighSierra.dmg</string>
+			<string>https://updates.cdn-apple.com/2019/macos/041-93820-20190729-96cd66e6-a61f-42c7-a586-40a6b70e6ecd/SecUpd2019-004HighSierra.dmg</string>
 		</dict>
 		<key>SecuritySierra</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -238,13 +238,13 @@
 		<key>SafariSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 12.1.1 for Sierra</string>
+			<string>Safari 12.1.2 for Sierra</string>
 			<key>sha1</key>
-			<string>15978e17326920649c166ee5ad97053f00f70489</string>
+			<string>15728ac0f915813ea4fe9191a3d63d9a2d6ce256</string>
 			<key>size</key>
-			<integer>81522032</integer>
+			<integer>81538403</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/51/43/041-30515/eqzkxl1jrr4clxza4mojehgnq7ijtf2pmw/Safari12.1.1Sierra.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/39/48/041-62930/6bwouqqzrf7uhexxs7z0k9ntun8ec0kmew/Safari12.1.2Sierra.pkg</string>
 		</dict>
 		<key>SafariYo</key>
 		<dict>
@@ -282,13 +282,13 @@
 		<key>SecuritySierra</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2019-003 (Sierra)</string>
+			<string>Security Update 2019-004 (Sierra)</string>
 			<key>sha1</key>
-			<string>c217a39fd1d14a1a568a6771ee8d5ee9f33a0f9c</string>
+			<string>4b4ff0b5e21710a9612f175d53d3049912bfebe0</string>
 			<key>size</key>
-			<integer>852326846</integer>
+			<integer>927685553</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2019/macos/041-44356-20190513-5056789d-9b1e-49c6-8d30-540a3d91442d/SecUpd2019-003Sierra.dmg</string>
+			<string>https://updates.cdn-apple.com/2019/macos/041-93816-20190729-ecd78564-1628-4e0e-b333-872dec7507e5/SecUpd2019-004Sierra.dmg</string>
 		</dict>
 		<key>SecurityYo</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -96,7 +96,7 @@
 			<string>17G6030</string>
 			<string>17G7024</string>
 		</array>
-		<key>10.14.6-18G84</key>
+		<key>10.14.6-18G87</key>
 		<array>
 			<string>18A293u</string>
 			<string>18A314h</string>
@@ -118,6 +118,7 @@
 			<string>18E2034</string>
 			<string>18F132</string>
 			<string>18F2058</string>
+			<string>18G84</string>
 		</array>
 	</dict>
 	<key>DeprecatedOSVersions</key>
@@ -170,6 +171,9 @@
 		</array>
 		<key>10.14.6-18G84</key>
 		<array>
+		</array>
+		<key>10.14.6-18G87</key>
+                <array>
 		</array>
 	</dict>
 	<key>PublicationDate</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -177,7 +177,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2019-07-23T14:05:36Z</date>
+	<date>2019-08-08T03:52:33Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AppStoreElCap</key>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -169,9 +169,6 @@
 		<key>10.13.6-17G7024</key>
 		<array>
 		</array>
-		<key>10.14.6-18G84</key>
-		<array>
-		</array>
 		<key>10.14.6-18G87</key>
                 <array>
 		</array>


### PR DESCRIPTION
This is an attempt to fix updates for a few different versions. The commits address:

* Security Update 004
* Sierra 12.1.2
* 10.14.6-18G87

This is my first attempt to update these configs, so a second set of eyes is appreciated. Specifically, these issues are not addressed in this pull request:

* The deprecation of 10.14.6-18G84 (for 10.14.6-18G87) may not be perfect
* I didn't try to add the 10.14.6 supplemental update



