### PR TITLE
Safari 14.0 updates + New macOS installers

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -212,13 +212,13 @@
 		<key>SafariMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 13.1.2 for Mojave</string>
+			<string>Safari 14.0 for Mojave</string>
 			<key>sha1</key>
-			<string>1a1daae9d64d5cb9ec6e5ff83ac7199d9ca5b0b3</string>
+			<string>418f24cdb5c0d372c71ad595a5bda2c87247e65b</string>
 			<key>size</key>
-			<integer>70582305</integer>
+			<integer>68925170</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/38/62/061-98246-A_DETHLIXKPC/njpb63acy0z0rgpdpewxts5rfjlkhtdvcy/Safari13.1.2MojaveAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/20/07/001-50026-A_8ANV58XVC7/nvqtw8plal39y2598inzzco2ekccgrrkx8/Safari14.0MojaveAuto.pkg</string>
 		</dict>
 		<key>SecurityHighSierra</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -189,9 +189,15 @@
 		</array>
 		<key>10.14.6-18G6020</key>
 		<array>
+			<string>SafariMojave</string>
 		</array>
 		<key>10.15.6-19G73</key>
 		<array>
+			<string>SafariCatalina</string>
+		</array>
+		<key>10.15.6-19G2021</key>
+		<array>
+			<string>SafariCatalina</string>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
@@ -219,6 +225,17 @@
 			<integer>68925170</integer>
 			<key>url</key>
 			<string>http://swcdn.apple.com/content/downloads/20/07/001-50026-A_8ANV58XVC7/nvqtw8plal39y2598inzzco2ekccgrrkx8/Safari14.0MojaveAuto.pkg</string>
+		</dict>
+		<key>SafariCatalina</key>
+		<dict>
+			<key>name</key>
+			<string>Safari 14.0 for Catalina</string>
+			<key>sha1</key>
+			<string>b2c875435fe249e7a99f53f729eb850960270ae9</string>
+			<key>size</key>
+			<integer>66987931</integer>
+			<key>url</key>
+			<string>http://swcdn.apple.com/content/downloads/00/48/001-50020-A_14M4NE130Q/q4lojf164rqsmp57dawdtgs25ut2d1j44m/Safari14.0CatalinaAuto.pkg</string>
 		</dict>
 		<key>SecurityHighSierra</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -201,7 +201,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2020-07-18T22:17:41Z</date>
+	<date>2020-09-17T13:14:13Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>SafariHighSierra</key>


### PR DESCRIPTION
Safari 14.0 updates + New macOS installers.

### Tests with AutoDMG

I built from scratch an image from a Mojave 18G103 installer + Safari 14.0 for Mojave + Security Update 2020-004 (Mojave). No extra updates were required after the first boot.

### Tests without AutoDMG

I did a fresh Catalina 19G2021 install in a VM a couple of days ago, basically untouched. No updates were required at that moment. Today I fired up again the VM and the Safari 14.0 for Catalina update popped up. Unfortunately I cannot build a Catalina 19G2021 + Safari 14.0 for Catalina image with AutoDMG, so I've not officially tested it in this way.

### Things not tested

I did a fresh Mojave 18G103 install a couple of days ago, after which I've applied the Security Update 2020-004 (Mojave) to bump the build number up to 18G6020. Since here a "10.14.6-18G6020" installer is listed, I assume that just applying the Safari 14.0 for Mojave update should be enough. Not tested, though, as I don't have that installer.

Since "10.15.6-19G2021" requires the Safari 14.0 for Catalina update, I assume that "10.15.6-19G73", as it's a previous version, requires the same update as well. Not tested, though, as I don't have that installer.

### Caveats

Apart from the assumptions above, I'm not sure whether some installers should be marked as deprecated or not.