### PR TITLE
10.15.7 + security update 2020-005

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -128,7 +128,7 @@
 			<string>18G3020</string>
 			<string>18G4032</string>
 		</array>
-		<key>10.15.6-19G73</key>
+		<key>10.15.7-19H2</key>
 		<array>
 			<string>19A536g</string>
 			<string>19A546d</string>
@@ -143,6 +143,8 @@
 			<string>19E287</string>
 			<string>19F96</string>
 			<string>19F101</string>
+			<string>19G73</string>
+			<string>19G2021</string>
 		</array>
 	</dict>
 	<key>DeprecatedOSVersions</key>
@@ -191,17 +193,13 @@
 		<array>
 			<string>SafariMojave</string>
 		</array>
-		<key>10.15.6-19G73</key>
-		<array>
-			<string>SafariCatalina</string>
-		</array>
-		<key>10.15.6-19G2021</key>
+		<key>10.15.7-19H2</key>
 		<array>
 			<string>SafariCatalina</string>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2020-09-17T13:14:13Z</date>
+	<date>2020-09-26T13:58:00Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>SafariHighSierra</key>
@@ -240,24 +238,24 @@
 		<key>SecurityHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2020-004 (High Sierra)</string>
+			<string>Security Update 2020-005 (High Sierra)</string>
 			<key>sha1</key>
-			<string>98342086c0527a181278779b5d66fddf780a503a</string>
+			<string>ccc73c56dd34fa65cae9af69d114d06d629437ed</string>
 			<key>size</key>
-			<integer>2113103355</integer>
+			<integer>2115552210</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2020/macos/001-08573-20200714-0996400b-0c1a-4dc9-9510-274ba6163785/SecUpd2020-004HighSierra.dmg</string>
+			<string>https://updates.cdn-apple.com/2020/macos/001-48383-20200924-dfcdb1e6-e5c7-47bf-883c-0808ac829113/SecUpd2020-005HighSierra.dmg</string>
 		</dict>
 		<key>SecurityMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2020-004 (Mojave)</string>
+			<string>Security Update 2020-005 (Mojave)</string>
 			<key>sha1</key>
-			<string>6f99b6bf8985dd78b905fc19bab1d87afdfe9e8c</string>
+			<string>0e63b31c08acfd4d3b85edd8da8dfc41346f1357</string>
 			<key>size</key>
-			<integer>1685198396</integer>
+			<integer>1685643621</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2020/macos/001-26310-20200714-e6a25de7-33b9-46eb-bb7d-cbdacda4f7dc/SecUpd2020-004Mojave.dmg</string>
+			<string>https://updates.cdn-apple.com/2020/macos/001-48329-20200924-122a4260-eb65-4492-b08e-f69dfa22c2dc/SecUpd2020-005Mojave.dmg</string>
 		</dict>
 		<key>SecuritySierra</key>
 		<dict>


### PR DESCRIPTION
## Changes

- Security Update 2020-005 for High Sierra
- Security Update 2020-005 for Mojave
- Catalina 10.15.7 installer (deprecates 10.15.6 installers)

## Tests

### High Sierra

I didn't have the chance to test on High Sierra; I've simply replaced the security update 2020-004 in the updates list with the 2020-005 one.

### Mojave

I've initialized a clean Mojave 10.14.6 (18G103) box and I've run the software update tool (excluding the upgrade to Catalina). I was notified of the following updates:
```console
Safari (14.0), 67309K [recommended]
Security Update 2020-005 (10.14.6), 1633218K [recommended] [restart]
```

I've downloaded the updates without installing them and I've run a SHA-1 checksum:

```console
Safari (14.0), 67309K [recommended]

418f24cdb5c0d372c71ad595a5bda2c87247e65b  /Library/Updates/001-50026/Safari14.0MojaveAuto.pkg


Security Update 2020-005 (10.14.6), 1633218K [recommended] [restart]

787b21e55a95c4a9695875ab8de62610715e702d  /Library/Updates/001-48327/EmbeddedOSFirmware.pkg
b3f9b4fdbaa48a37416d7fda141dca32b85596fe  /Library/Updates/001-48327/FirmwareUpdate.pkg
e1ba37a491edffb31af9d4b6536750b7c208ba12  /Library/Updates/001-48327/FullBundleUpdate.pkg
4ed85c93fa0e97c5d2019e0f03f0f51afa941d8a  /Library/Updates/001-48327/SecUpd2020-005Mojave.RecoveryHDUpdate.pkg
645a4daf0731ce8de974ac3bb9e16c98d2ba3668  /Library/Updates/001-48327/SecUpd2020-005Mojave.pkg
df8abbf0b0a8856af86ea59d75904f106cc4b92e  /Library/Updates/001-48327/SecureBoot.pkg
022d3c08180121ee5c4fffaed3cfe1f2024d1b76  /Library/Updates/001-48327/macOSBrain.pkg
```

- Safari's update (id `001-50026`) has the same id and checksum of the one already present in `UpdateProfiles.plist`
- The security update has id `001-48327`, which clashes with the id `001-48329` that you get by downloading the update from Apple's download center. I was not able to match the checksum of `001-48327` and `001-48329`, because the `.pkg`s contained in Apple's download center installer seem to be just folders and not actual files. Anyway, I believe they are the same update, just packaged in a different way.

I've then installed both Safari 14.0 and the Security Update 2020-005 from the links I've put in `UpdateProfiles.plist` (not the ones I've downloaded from software update), I've rebooted and I've checked again for updates; no updates were available at that point.

After the updates, the build number was bumped to 18G6032.

### Catalina

I've initialized a clean Catalina 10.15.7 (19H2) box and I've run the software update tool. I was notified of the following updates:
```console
Safari, Version: 14.0, Size: 65417K, Recommended: YES
```

I've downloaded the updates without installing them and I've run a SHA-1 checksum:

```console
Safari, Version: 14.0, Size: 65417K, Recommended: YES

b2c875435fe249e7a99f53f729eb850960270ae9  /Library/Updates/001-50020/Safari14.0CatalinaAuto.pkg
```

Safari's update (id `001-50020`) has the same id and checksum of the one already present in `UpdateProfiles.plist`.

I've then installed Safari 14.0 from the link I've put in `UpdateProfiles.plist` (not the one I've downloaded from software update), I've rebooted and I've checked again for updates; no updates were available at that point.

After the updates, the build number was still 19H2.