### PR TITLE
macOS Mojave 10.14.6 Supplemental Update

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -187,7 +187,7 @@
 		<key>10.14.6-18G103</key>
 		<array>
 			<string>SecurityMojave</string>
-			<string>SafariMojave</string>
+			<string>SupplementalMojave</string>
 		</array>
 		<key>10.14.6-18G6020</key>
 		<array>
@@ -199,7 +199,7 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2020-09-26T13:58:00Z</date>
+	<date>2020-10-07T13:13:00Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>SafariHighSierra</key>
@@ -213,7 +213,7 @@
 			<key>url</key>
 			<string>http://swcdn.apple.com/content/downloads/33/34/061-96797-A_PBSVGZX5CC/dt6bdxuqhtv0ck6n0ukx62xry7p6svl9bp/Safari13.1.2HighSierraAuto.pkg</string>
 		</dict>
-		<key>SafariMojave</key>
+		<key>SupplementalMojave</key>
 		<dict>
 			<key>name</key>
 			<string>macOS Mojave 10.14.6 Supplemental Update</string>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -216,13 +216,13 @@
 		<key>SafariMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 14.0 for Mojave</string>
+			<string>macOS Mojave 10.14.6 Supplemental Update</string>
 			<key>sha1</key>
-			<string>418f24cdb5c0d372c71ad595a5bda2c87247e65b</string>
+			<string>58dc3047f1f168cf0ca4f05cf64fd9cf3f4e0293</string>
 			<key>size</key>
-			<integer>68925170</integer>
+			<integer>68925626</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/20/07/001-50026-A_8ANV58XVC7/nvqtw8plal39y2598inzzco2ekccgrrkx8/Safari14.0MojaveAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/08/46/001-55225-A_FKPERA412C/z81r8bvj47p12e0pvcz9dj33l43z7h201b/Safari14.0MojaveAuto.pkg</string>
 		</dict>
 		<key>SafariCatalina</key>
 		<dict>

--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -186,8 +186,8 @@
 		</array>
 		<key>10.14.6-18G103</key>
 		<array>
-			<string>SafariMojave</string>
 			<string>SecurityMojave</string>
+			<string>SafariMojave</string>
 		</array>
 		<key>10.14.6-18G6020</key>
 		<array>


### PR DESCRIPTION
Supplemental Update for 10.14.6. Solves some issues derived from combining Safari 14.0 and the Security Update 2020-005; on a clean installation it seems to be a replacement for Safari's 14.0 update package, so I've re-used the `SafariMojave` tag. The Security Update 2020-005 was first pulled following the issues and then re-enabled, but the product ID (and the download link) is exactly the same, so there's no need to change it.

I've tested the combination of these two updates on a clean Mojave 10.14.6 (18G103) box without any issues; the supplemental update doesn't change the resulting macOS build number.