### PR TITLE
10.15.7 Supplemental update

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -194,11 +194,12 @@
 		</array>
 		<key>10.15.7-19H2</key>
 		<array>
+			<string>SupplementalCatalina</string>
 			<string>SafariCatalina</string>
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2020-10-09T16:13:00Z</date>
+	<date>2020-11-10T20:25:44Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>SafariHighSierra</key>
@@ -233,6 +234,17 @@
 			<integer>66987931</integer>
 			<key>url</key>
 			<string>http://swcdn.apple.com/content/downloads/00/48/001-50020-A_14M4NE130Q/q4lojf164rqsmp57dawdtgs25ut2d1j44m/Safari14.0CatalinaAuto.pkg</string>
+		</dict>
+		<key>SupplementalCatalina</key>
+		<dict>
+			<key>name</key>
+			<string>macOS Catalina 10.15.7 Supplemental Update</string>
+			<key>sha1</key>
+			<string>23a740a2146e976a2bf7752195a4f744c40f9187</string>
+			<key>size</key>
+			<integer>1222040585</integer>
+			<key>url</key>
+			<string>https://updates.cdn-apple.com/2020/macos/001-69961-20201103-fe1663ca-c874-4f17-b1ee-07b1dce871ab/macOSUpd10.15.7Supplemental.dmg</string>
 		</dict>
 		<key>SecurityHighSierra</key>
 		<dict>


### PR DESCRIPTION
Adds supplemental update that gets Catalina to build 19H15

(I think there is a problem with the previous Mojave/Safari Supplemental, the download link gives a 404 now. I don't have a Mojave computer handy to test with though.)