### PR TITLE
Catalina & Mojave updates

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -201,19 +201,19 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2020-12-17T23:00:44Z</date>
+	<date>2021-02-10T17:41:44Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>SafariCatalina</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 14.0.2 for Catalina</string>
+			<string>Safari 14.0.3 for Catalina</string>
 			<key>sha1</key>
-			<string>975871a721cfaf6aba3d88d6a1af3a0a22286106</string>
+			<string>ecd056d15d90469dd435838c6e6e0143a334ad60</string>
 			<key>size</key>
-			<integer>67753817</integer>
+			<integer>83375420</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/63/30/001-56838-A_7SXU0G9D7J/ur3ns88csh3uz4jcb6olzmu8fc6skl098y/Safari14.0.2CatalinaAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/50/26/071-03270-A_GJPM2L0AB0/ktfbkvzeaa5k8ppaxfl1gbmfcjbgorrpw5/Safari14.0.3CatalinaAuto.pkg</string>
 		</dict>
 		<key>SafariHighSierra</key>
 		<dict>
@@ -229,24 +229,24 @@
 		<key>SafariMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 14.0.2 for Mojave</string>
+			<string>Safari 14.0.3 for Mojave</string>
 			<key>sha1</key>
-			<string>334941fbcb43ca2266fe6f8c9782b4ae7f5dee13</string>
+			<string>4003034cf8a5e91b831387d7f4074789c48e849e</string>
 			<key>size</key>
-			<integer>69698902</integer>
+			<integer>85316209</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/35/10/001-55939-A_5C6C05U1VW/djn0z87dja2oivnzuc4raqehgjeisxv2k9/Safari14.0.2MojaveAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/11/29/001-84810-A_C5VAXC16QW/ovsfkhzxxe6k30ii1elcuvkt5z1k9viico/Safari14.0.3MojaveAuto.pkg</string>
 		</dict>
 		<key>SecurityCatalina</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2020-001 (Catalina)</string>
+			<string>Security Update 2021-001 + Supplemental (Catalina)</string>
 			<key>sha1</key>
-			<string>7ecc3f8ec56f98592fc1d09ab105c15dbc18c375</string>
+			<string>e7c45a499b742009e4cbf84ecb49efd1b32ea947</string>
 			<key>size</key>
-			<integer>1325474811</integer>
+			<integer>1350059291</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2020/macos/001-88091-20201214-6a779724-e66e-4dff-b4af-93751f8a1f66/SecUpd2020-001Catalina.dmg</string>
+			<string>https://updates.cdn-apple.com/2021/macos/071-05427-20210207-b65aec0c-f253-4ffe-9f4b-315edb84de46/SecUpd2021-001Catalina.dmg</string>
 		</dict>
 		<key>SecurityHighSierra</key>
 		<dict>
@@ -262,13 +262,13 @@
 		<key>SecurityMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2020-007 (Mojave)</string>
+			<string>Security Update 2021-002 (Mojave)</string>
 			<key>sha1</key>
-			<string>d9352f764985b3b936460075ca2ede712a51ed6e</string>
+			<string>9b741b1e1226b568946cb1f411367dd2d67e8d06</string>
 			<key>size</key>
-			<integer>1704838184</integer>
+			<integer>1748832207</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2020/macos/001-88087-20201214-9cd71c15-0fe9-4613-8b80-454fb5a5b4d0/SecUpd2020-007Mojave.dmg</string>
+			<string>https://updates.cdn-apple.com/2021/macos/071-05175-20210207-03280719-b9d8-45d1-ac9d-263b0db3d7f6/SecUpd2021-002Mojave.dmg</string>
 		</dict>
 		<key>SecuritySierra</key>
 		<dict>


### PR DESCRIPTION
Includes Mojave Security Update 2021-001 and Catalina Security Update 2021-001 + Supplemental along with Safari 14.0.3 for both.