### PR TITLE
Security and Safari updates

### DIFF
--- a/UpdateProfiles.plist
+++ b/UpdateProfiles.plist
@@ -201,19 +201,19 @@
 		</array>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2021-06-07T17:17:44Z</date>
+	<date>2021-08-05T18:09:44Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>SafariCatalina</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 14.1.1 for Catalina</string>
+			<string>Safari 14.1.2 for Catalina</string>
 			<key>sha1</key>
-			<string>bb740a6b391ac5ee0d7ff0602198f51228a14b97</string>
+			<string>568f52949582a94dd0b35a0e935d4e9967fa0c9f</string>
 			<key>size</key>
-			<integer>93545840</integer>
+			<integer>93620479</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/33/62/071-21211-A_YV5ESAI9E9/rjfqnpg4pbkua6dyay9yb89ryp6veq2pt1/Safari14.1.1CatalinaAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/46/17/071-40187-A_J8Y2FGUB4F/e7fribz1mwzdljlm1w8q60n7dbn0nwoa9a/Safari14.1.2CatalinaAuto.pkg</string>
 		</dict>
 		<key>SafariHighSierra</key>
 		<dict>
@@ -229,24 +229,24 @@
 		<key>SafariMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 14.1.1 for Mojave</string>
+			<string>Safari 14.1.2 for Mojave</string>
 			<key>sha1</key>
-			<string>114b73bff367a3dac3fff88c9154cd0fcf166846</string>
+			<string>25247b54b68351a38b67b2ae6e2669d6d8006fa8</string>
 			<key>size</key>
-			<integer>95574232</integer>
+			<integer>95638688</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/25/25/071-21058-A_0EB828RCS8/leq8j3xiafddw07ydrwzm5nssep8mpt4aq/Safari14.1.1MojaveAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/44/05/071-47373-A_9A3CD8EVNY/jpiompzkddnter5tm1094w57tg63ok0axz/Safari14.1.2MojaveAuto.pkg</string>
 		</dict>
 		<key>SecurityCatalina</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2021-003 (Catalina)</string>
+			<string>Security Update 2021-004 (Catalina)</string>
 			<key>sha1</key>
-			<string>cf455e1275128988fabc7009a842d7cb60f6064a</string>
+			<string>816b8cb7c50608b1bb554d8216e2e139544485cc</string>
 			<key>size</key>
-			<integer>1433020504</integer>
+			<integer>1440789047</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2021/macos/071-28857-20210521-540e2feb-2bfc-474e-8679-258749df81ec/SecUpd2021-003Catalina.dmg</string>
+			<string>https://updates.cdn-apple.com/2021/macos/071-41288-20210729-CEC04B4D-DF02-48DD-817A-8681306121E1/SecUpd2021-004Catalina.dmg</string>
 		</dict>
 		<key>SecurityHighSierra</key>
 		<dict>
@@ -262,13 +262,13 @@
 		<key>SecurityMojave</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2021-004 (Mojave)</string>
+			<string>Security Update 2021-005 (Mojave)</string>
 			<key>sha1</key>
-			<string>aaa1f5343582a002f77b0a184a032103177e7fac</string>
+			<string>9d13008bfa8cf2b6f524a2db9b58b88d80f07e0a</string>
 			<key>size</key>
-			<integer>1787845633</integer>
+			<integer>1791756053</integer>
 			<key>url</key>
-			<string>https://updates.cdn-apple.com/2021/macos/071-28862-20210521-6747a4b2-ac3c-42a3-8aa1-49f5f1024dfe/SecUpd2021-004Mojave.dmg</string>
+			<string>https://updates.cdn-apple.com/2021/macos/071-44388-20210729-E9ABD965-02E6-4DDB-B671-C9791D4F5006/SecUpd2021-005Mojave.dmg</string>
 		</dict>
 		<key>SecuritySierra</key>
 		<dict>


### PR DESCRIPTION
Catalina 2021-004
Mojave 2021-005
Safari 4.1.12